### PR TITLE
Require 'time' to avoid undefined method "parse" errors

### DIFF
--- a/lib/dropbox_api.rb
+++ b/lib/dropbox_api.rb
@@ -1,5 +1,6 @@
 require 'dropbox_api/version'
 
+require 'time'
 require 'json'
 require 'faraday'
 


### PR DESCRIPTION
I was getting errors when trying to do things like `client.share_folder('/something/foo')`. The errors were in the `force_cast` method of `lib/dropbox_api/metadata/field.rb`, and requiring "time" fixes them.

Thanks,

Scott