### PR TITLE
Bump version number to 0.1.2

### DIFF
--- a/lib/dropbox_api/version.rb
+++ b/lib/dropbox_api/version.rb
@@ -1,3 +1,3 @@
 module DropboxApi
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end


### PR DESCRIPTION
There's a wrong version number in lib/dropbox_api/version.rb which makes upgrading a bit hard...