### PR TITLE
Support for upload endpoint options

### DIFF
--- a/lib/dropbox_api/endpoints/files/upload.rb
+++ b/lib/dropbox_api/endpoints/files/upload.rb
@@ -5,6 +5,8 @@ module DropboxApi::Endpoints::Files
     ResultType  = DropboxApi::Metadata::File
     ErrorType   = DropboxApi::Errors::UploadError
 
+    include DropboxApi::Endpoints::OptionsValidator
+
     # @method upload(path, content, options = {})
     # Creates a new file.
     #
@@ -23,6 +25,8 @@ module DropboxApi::Endpoints::Files
     # @param path [String] Path in the user's Dropbox to save the file.
     # @param content The contents of the file that will be uploaded. This
     #   could be the result of the +IO::read+ method.
+    # @option options mode [:add, :overwrite, :update] Selects what to do if
+    #   the file already exists. The default for this union is add.
     # @option options autorename [Boolean] If there's a conflict, as
     #   determined by mode, have the Dropbox server try to autorename the
     #   file to avoid conflict. The default for this field is False.
@@ -32,7 +36,13 @@ module DropboxApi::Endpoints::Files
     #   shouldn't result in a user notification. The default for this field is
     #   `false`.
     add_endpoint :upload do |path, content, options = {}|
-      perform_request({:path => path}, content)
+      validate_options([
+        :mode,
+        :autorename,
+        :mute
+      ], options)
+
+      perform_request(options.merge({:path => path}), content)
     end
   end
 end

--- a/spec/endpoints/files_spec.rb
+++ b/spec/endpoints/files_spec.rb
@@ -417,6 +417,20 @@ context DropboxApi::Endpoints::Files do
       expect(file.name).to eq("file.txt")
     end
 
+    it "overwrites the uploaded file if it exists and the mode is :overwrite", :cassette => "upload/success_overwrite" do
+      file = @client.upload("/file.txt", "Hello Again, Dropbox!", :mode => :overwrite)
+
+      expect(file).to be_a(DropboxApi::Metadata::File)
+      expect(file.name).to eq("file.txt")
+    end
+
+    it "renames the uploaded file if required", :cassette => "upload/success_rename" do
+      file = @client.upload("/file.txt", "Hello Again, Dropbox!", :autorename => true)
+
+      expect(file).to be_a(DropboxApi::Metadata::File)
+      expect(file.name).to eq("file (1).txt")
+    end
+
     context "when too many write operations" do
       it "raises a DropboxApi::Errors::TooManyWriteOperations exception", :cassette => "upload/too_many_write_operations" do
         expect {

--- a/spec/fixtures/vcr_cassettes/upload/success_overwrite.yml
+++ b/spec/fixtures/vcr_cassettes/upload/success_overwrite.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://content.dropboxapi.com/2/files/upload
+    body:
+      encoding: UTF-8
+      string: Hello Again, Dropbox!
+    headers:
+      Authorization:
+      - Bearer MOCK_AUTHORIZATION_BEARER
+      User-Agent:
+      - Faraday v0.9.2
+      Dropbox-Api-Arg:
+      - '{"mode":"overwrite","path":"/file.txt"}'
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 26 Dec 2016 14:10:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      X-Server-Response-Time:
+      - '747'
+      X-Dropbox-Request-Id:
+      - c190700490205a0c4661035cbbf4bcf3
+      X-Robots-Tag:
+      - noindex, nofollow, noimageindex
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name": "file.txt", "path_lower": "/file.txt", "path_display": "/file.txt",
+        "id": "id:lupHTAlMQvkAAAAAAAAAKg", "client_modified": "2016-12-26T14:10:10Z",
+        "server_modified": "2016-12-26T14:10:11Z", "rev": "6f299384b6", "size": 21}'
+    http_version:
+  recorded_at: Mon, 26 Dec 2016 14:10:16 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/upload/success_rename.yml
+++ b/spec/fixtures/vcr_cassettes/upload/success_rename.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://content.dropboxapi.com/2/files/upload
+    body:
+      encoding: UTF-8
+      string: Hello Again, Dropbox!
+    headers:
+      Authorization:
+      - Bearer MOCK_AUTHORIZATION_BEARER
+      User-Agent:
+      - Faraday v0.9.2
+      Dropbox-Api-Arg:
+      - '{"autorename":true,"path":"/file.txt"}'
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 26 Dec 2016 14:07:27 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      X-Server-Response-Time:
+      - '665'
+      X-Dropbox-Request-Id:
+      - 7ff9ad669dc7701632f0a2f4a87d7b44
+      X-Robots-Tag:
+      - noindex, nofollow, noimageindex
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name": "file (1).txt", "path_lower": "/file (1).txt", "path_display":
+        "/file (1).txt", "id": "id:lupHTAlMQvkAAAAAAAAALA", "client_modified": "2016-12-26T14:07:27Z",
+        "server_modified": "2016-12-26T14:07:27Z", "rev": "6e299384b6", "size": 21}'
+    http_version:
+  recorded_at: Mon, 26 Dec 2016 14:07:32 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Found out the same option was allowed in the `upload` endpoint (and I needed it), so adding it similarly to what you did in https://github.com/Jesus/dropbox_api/issues/11. Also added support for `mute` and `mode` options.