### PR TITLE
Rescue exception if endpoint is already gone

### DIFF
--- a/spec/fixtures/dropbox_scaffold_builder.rb
+++ b/spec/fixtures/dropbox_scaffold_builder.rb
@@ -4,7 +4,7 @@ class DropboxScaffoldBuilder
   def clobber(endpoint_name)
     client.delete(endpoint_prefix endpoint_name)
   rescue DropboxApi::Errors::NotFoundError
-    # already gone
+    false
   end
 
   def generate(endpoint_name)

--- a/spec/fixtures/dropbox_scaffold_builder.rb
+++ b/spec/fixtures/dropbox_scaffold_builder.rb
@@ -2,7 +2,11 @@ class DropboxScaffoldBuilder
   PREFIX = "/dropbox_api_fixtures"
 
   def clobber(endpoint_name)
-    client.delete(endpoint_prefix endpoint_name)
+    begin
+      client.delete(endpoint_prefix endpoint_name)
+    rescue DropboxApi::Errors::NotFoundError
+      # already gone
+    end
   end
 
   def generate(endpoint_name)

--- a/spec/fixtures/dropbox_scaffold_builder.rb
+++ b/spec/fixtures/dropbox_scaffold_builder.rb
@@ -2,11 +2,9 @@ class DropboxScaffoldBuilder
   PREFIX = "/dropbox_api_fixtures"
 
   def clobber(endpoint_name)
-    begin
-      client.delete(endpoint_prefix endpoint_name)
-    rescue DropboxApi::Errors::NotFoundError
-      # already gone
-    end
+    client.delete(endpoint_prefix endpoint_name)
+  rescue DropboxApi::Errors::NotFoundError
+    # already gone
   end
 
   def generate(endpoint_name)


### PR DESCRIPTION
Running clobber on an empty Dropbox directory (eg: empty state) would generate a `DropboxApi::Errors::NotFoundError` exception.