### PR TITLE
content_hash is missing from /list_folder

### DIFF
--- a/api_coverage.md
+++ b/api_coverage.md
@@ -24,7 +24,7 @@ API call | Status
 `/get_preview` | 🌕
 `/get_temporary_link` | 🌕
 `/get_thumbnail` | 🌕
-`/list_folder` | 🌕
+`/list_folder` | 🌔
 `/list_folder/continue` | 🌕
 `/list_folder/get_latest_cursor` | 🌕
 `/list_folder/longpoll` | 🌕


### PR DESCRIPTION
`content_hash` is not returned for entries returned by `/list_folder`

https://www.dropbox.com/developers/documentation/http/documentation#files-list_folder