### PR TITLE
Update UploadSessionCursor offset when appending uploads (fixes #24)

### DIFF
--- a/lib/dropbox_api/endpoints/files/upload_session_append_v2.rb
+++ b/lib/dropbox_api/endpoints/files/upload_session_append_v2.rb
@@ -28,6 +28,8 @@ module DropboxApi::Endpoints::Files
       perform_request(options.merge({
         :cursor => cursor.to_hash
       }), content)
+
+      cursor.offset += content.bytesize
     end
   end
 end

--- a/lib/dropbox_api/metadata/upload_session_cursor.rb
+++ b/lib/dropbox_api/metadata/upload_session_cursor.rb
@@ -7,5 +7,9 @@ module DropboxApi::Metadata
   class UploadSessionCursor < Base
     field :session_id, String
     field :offset, Integer
+
+    def offset=(n)
+      self[:offset] = n
+    end
   end
 end

--- a/spec/endpoints/files/upload_session_append_v2_spec.rb
+++ b/spec/endpoints/files/upload_session_append_v2_spec.rb
@@ -3,14 +3,19 @@ describe DropboxApi::Client, "#upload_session_append_v2" do
     @client = DropboxApi::Client.new
   end
 
-  it "can use the cursor returned by #upload_session_start", :cassette => "upload_session_append_v2/success" do
-    chunks = ["123456789", "Hello Dropbox!"]
+  it 'can be used to append an upload', cassette: 'upload_session_append_v2/success' do
+    chunks = ['123456789', 'Olá Dropbox!']
 
     cursor = @client.upload_session_start(chunks.first)
 
     @client.upload_session_append_v2(cursor, chunks.last)
 
-    # The endpoint doesn't have any return values, can't test the output!
+    commit = DropboxApi::Metadata::CommitInfo.new(
+      'path' => '/target.txt',
+      'mode' => :add
+    )
+
+    expect { @client.upload_session_finish(cursor, commit) }.not_to raise_error
   end
 
   it "will raise error if the cursor can't be found", :cassette => "upload_session_append_v2/not_found" do

--- a/spec/fixtures/vcr_cassettes/upload_session_append_v2/success.yml
+++ b/spec/fixtures/vcr_cassettes/upload_session_append_v2/success.yml
@@ -10,7 +10,7 @@ http_interactions:
       Authorization:
       - Bearer MOCK_AUTHORIZATION_BEARER
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v0.12.1
       Dropbox-Api-Arg:
       - "{}"
       Content-Type:
@@ -27,41 +27,43 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 09 Jan 2017 19:30:41 GMT
+      - Tue, 20 Jun 2017 23:16:24 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
+      Vary:
+      - Accept-Encoding
       Pragma:
       - no-cache
       Cache-Control:
       - no-cache
       X-Server-Response-Time:
-      - '341'
+      - '270'
       X-Dropbox-Request-Id:
-      - 38b20b777790be090e32e69d2c55765f
+      - 35f0b9314f31e404fbbd9908e52fe763
       X-Robots-Tag:
       - noindex, nofollow, noimageindex
     body:
       encoding: ASCII-8BIT
-      string: '{"session_id": "AAAAAAAABCJ61k9yZZtn8Q"}'
-    http_version:
-  recorded_at: Mon, 09 Jan 2017 19:30:41 GMT
+      string: '{"session_id": "AAAAAAAAF15DUkd3feKuMA"}'
+    http_version: 
+  recorded_at: Tue, 20 Jun 2017 23:16:25 GMT
 - request:
     method: post
     uri: https://content.dropboxapi.com/2/files/upload_session/append_v2
     body:
       encoding: UTF-8
-      string: Hello Dropbox!
+      string: Olá Dropbox!
     headers:
       Authorization:
       - Bearer MOCK_AUTHORIZATION_BEARER
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v0.12.1
       Dropbox-Api-Arg:
-      - '{"cursor":{"session_id":"AAAAAAAABCJ61k9yZZtn8Q","offset":9}}'
+      - '{"cursor":{"session_id":"AAAAAAAAF15DUkd3feKuMA","offset":9}}'
       Content-Type:
       - application/octet-stream
       Accept-Encoding:
@@ -76,26 +78,84 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 09 Jan 2017 19:30:42 GMT
+      - Tue, 20 Jun 2017 23:16:26 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
+      Vary:
+      - Accept-Encoding
       Pragma:
       - no-cache
       Cache-Control:
       - no-cache
       X-Server-Response-Time:
-      - '349'
+      - '367'
       X-Dropbox-Request-Id:
-      - 4ebf9f40ef02aca8a708722c5f3d35c0
+      - f252c67365bbb23e1fc911680b6d391b
       X-Robots-Tag:
       - noindex, nofollow, noimageindex
     body:
       encoding: ASCII-8BIT
       string: 'null'
-    http_version:
-  recorded_at: Mon, 09 Jan 2017 19:30:42 GMT
-recorded_with: VCR 3.0.1
+    http_version: 
+  recorded_at: Tue, 20 Jun 2017 23:16:26 GMT
+- request:
+    method: post
+    uri: https://content.dropboxapi.com/2/files/upload_session/finish
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_AUTHORIZATION_BEARER
+      User-Agent:
+      - Faraday v0.12.1
+      Dropbox-Api-Arg:
+      - '{"cursor":{"session_id":"AAAAAAAAF15DUkd3feKuMA","offset":22},"commit":{"path":"/target.txt","mode":{".tag":"add"}}}'
+      Content-Type:
+      - application/octet-stream
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 20 Jun 2017 23:16:27 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      X-Server-Response-Time:
+      - '652'
+      X-Dropbox-Request-Id:
+      - 86a9fbfb2899b0be3ac68875480ff0d7
+      X-Robots-Tag:
+      - noindex, nofollow, noimageindex
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name": "target.txt", "path_lower": "/target.txt", "path_display":
+        "/target.txt", "id": "id:QKdce33OfLAAAAAAAAAAFw", "client_modified": "2017-06-20T23:16:27Z",
+        "server_modified": "2017-06-20T23:16:27Z", "rev": "1f58ebb611", "size": 22,
+        "content_hash": "2064faa877255c7097e19c8ce5daada411478d0bfb8ed57837eeaa53bd4a10b3"}'
+    http_version: 
+  recorded_at: Tue, 20 Jun 2017 23:16:28 GMT
+recorded_with: VCR 3.0.3

--- a/spec/metadata/upload_session_cursor_spec.rb
+++ b/spec/metadata/upload_session_cursor_spec.rb
@@ -9,4 +9,14 @@ describe DropboxApi::Metadata::UploadSessionCursor do
     expect(cursor.session_id).to eq("2c824061bdd")
     expect(cursor.offset).to eq(1136802)
   end
+
+  it 'can have its offset modified' do
+    cursor = described_class.new(
+      'session_id' => '2c824061bdd',
+      'offset' => 0
+    )
+
+    expect { cursor.offset = 42 }
+      .to change { cursor.offset }.from(0).to(42)
+  end
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -18,6 +18,13 @@ VCR.configure do |config|
       }
     ]
   }
+
+  # If the environment variable DROPBOX_OAUTH_BEARER is present, its value
+  # appearing inside any cassette will automatically be replaced with the
+  # string "MOCK_AUTHORIZATION_BEARER".
+  config.filter_sensitive_data('MOCK_AUTHORIZATION_BEARER') do
+    ENV['DROPBOX_OAUTH_BEARER']
+  end
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
Fixes #24, where using `upload_session_append_v2` in conjunction with `upload_session_finish` will always raise an error due to the offset not being correctly accounted for.

As this seems to be the only intended use of `upload_session_append_v2`, I've adjusted the spec to include a call to `upload_session_finish`, which will cause a failing test where one wasn't before.