### PR TITLE
Fix Content-Length error

### DIFF
--- a/lib/dropbox_api/endpoints/content_upload.rb
+++ b/lib/dropbox_api/endpoints/content_upload.rb
@@ -14,6 +14,11 @@ module DropboxApi::Endpoints
         'Dropbox-API-Arg' => JSON.dump(params),
         'Content-Type' => 'application/octet-stream'
       }
+      if body.respond_to?(:length)
+        headers['Content-Length'] = body.length.to_s
+      elsif body.respond_to?(:stat)
+        headers['Content-Length'] = body.stat.size.to_s
+      end
 
       return body, headers
     end


### PR DESCRIPTION
I ran into #26 as well, and this seems like a simple fix that wouldn't have any side effects.

To help you replicate the issue, I'm calling `upload` as follows:

`client.upload('some_path.xlsx', contents, mode: :overwrite)`

`contents` is generated as follows:

``` ruby
contents = Tempfile.new([order.number, '.xlsx'], binmode: true).tap do |f|
  f.write #...some binary data
  f.flush
  f.rewind
end
```

By applying this commit, it works fine for me. 

cc/ @simi for the inspiration on the fix