### PR TITLE
Allow for custom Faraday middleware

### DIFF
--- a/lib/dropbox_api.rb
+++ b/lib/dropbox_api.rb
@@ -7,6 +7,7 @@ require 'faraday'
 require 'dropbox_api/authenticator'
 
 require 'dropbox_api/middleware/decode_result'
+require 'dropbox_api/middleware/stack'
 
 require 'dropbox_api/metadata/field'
 require 'dropbox_api/metadata/base'

--- a/lib/dropbox_api/client.rb
+++ b/lib/dropbox_api/client.rb
@@ -4,6 +4,10 @@ module DropboxApi
       @connection_builder = ConnectionBuilder.new(oauth_bearer)
     end
 
+    def middleware
+      @connection_builder.middleware
+    end
+
     # @!visibility private
     def self.add_endpoint(name, endpoint)
       define_method(name) do |*args, &block|

--- a/lib/dropbox_api/connection_builder.rb
+++ b/lib/dropbox_api/connection_builder.rb
@@ -4,13 +4,17 @@ module DropboxApi
       @oauth_bearer = oauth_bearer
     end
 
+    def middleware
+      @middleware ||= MiddleWare::Stack.new
+    end
+
     def build(url)
-      Faraday.new(url) do |c|
-        c.authorization :Bearer, @oauth_bearer
+      Faraday.new(url) do |connection|
+        middleware.apply(connection) do
+          connection.authorization :Bearer, @oauth_bearer
 
-        yield c
-
-        c.adapter Faraday.default_adapter
+          yield connection
+        end
       end
     end
   end

--- a/lib/dropbox_api/middleware/stack.rb
+++ b/lib/dropbox_api/middleware/stack.rb
@@ -1,0 +1,28 @@
+module DropboxApi::MiddleWare
+  class Stack
+    def initialize
+      @prependable, @appendable = [], []
+    end
+
+    def prepend(&block)
+      @prependable << block
+    end
+
+    def append(&block)
+      @appendable << block
+    end
+
+    def adapter=(value)
+      @adapter = value
+    end
+
+    def apply(connection)
+      @prependable.each { |block| block.yield(connection) }
+      yield connection
+      @appendable.each { |block| block.yield(connection) }
+
+      # Adapter must be the last middleware configured
+      connection.adapter(@adapter || Faraday.default_adapter)
+    end
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,33 @@
+module DropboxApi
+  describe Client do
+    it 'can have custom connection middleware' do
+      # Mock middleware
+      MiddlewareStart = Class.new
+      MiddlewareMiddle = Class.new
+      MiddlewareEnd = Class.new
+
+      # Attach a dummy endpoint that will return the internal connection builder
+      connection_builder_endpoint = Struct.new(:connection_builder)
+      Client.add_endpoint :connection_builder, connection_builder_endpoint
+
+      client = Client.new
+
+      # Configure middleware
+      client.middleware.prepend { |faraday| faraday.use MiddlewareStart }
+      client.middleware.append { |faraday| faraday.use MiddlewareEnd }
+      client.middleware.adapter = :net_http_persistent
+
+      # Insert middleware as an endpoint might
+      connection = client.connection_builder.build('http://example.org') do |faraday|
+        faraday.use MiddlewareMiddle
+      end
+
+      expect(connection.builder.handlers).to eq [
+        MiddlewareStart,
+        MiddlewareMiddle,
+        MiddlewareEnd,
+        Faraday::Adapter::NetHttpPersistent
+      ]
+    end
+  end
+end


### PR DESCRIPTION
Addresses #29.

Introduces a method called `middleware` on the `Client`, that can be used like this:

```ruby
client = DropboxApi::Client.new

client.middleware.prepend do |connection|
  connection.request LoggingMiddleware
end

client.middleware.append do |connection|
  connection.use InstrumentationMiddleware
end
```

The order of middleware is important, so `prepend` will let you set up the connection before `DropboxApi` modifies it (via an endpoint's `builder.build` call – usually in an initializer) and `append` will let you alter the connection after `DropboxApi` modifies it.

As the `adapter` must be the last item of middleware, there's one extra method on the `middleware` object, `adapter=`:

```ruby
# Use the Excon gem instead of Net::HTTP to make requests
client.middleware.adapter = :excon
```