### PR TITLE
Add Shared Link option (url) to list_folder

### DIFF
--- a/lib/dropbox_api/endpoints/files/list_folder.rb
+++ b/lib/dropbox_api/endpoints/files/list_folder.rb
@@ -23,6 +23,7 @@ module DropboxApi::Endpoints::Files
         :recursive,
         :include_media_info,
         :include_deleted,
+        :shared_link,
         :include_has_explicit_shared_members
       ], options)
       options[:recursive] ||= false


### PR DESCRIPTION
Simply add the option shared_link to find and list a folder using the list_folder endpoint.