### PR TITLE
Handle empty i_stream in chunked uploader start call.

### DIFF
--- a/lib/dropbox_api/chunked_uploader.rb
+++ b/lib/dropbox_api/chunked_uploader.rb
@@ -13,6 +13,7 @@ module DropboxApi
 
     def start
       chunk = @i_stream.read @chunk_size
+      chunk = "" if chunk.nil?
 
       @cursor = @client.upload_session_start chunk
     end

--- a/spec/chunked_uploader_spec.rb
+++ b/spec/chunked_uploader_spec.rb
@@ -6,6 +6,20 @@ module DropboxApi
       @client = DropboxApi::Client.new
     end
 
+    it 'uploads a empty string', :cassette => "chunked_uploader/success_with_empty_string" do
+      content = StringIO.new("")
+
+      uploader = DropboxApi::ChunkedUploader.new(@client, "#{path_prefix}/new_file.txt", content, {
+        :chunk_size => 4
+      })
+      uploader.start
+      uploader.upload
+      file_data = uploader.finish
+
+      expect(file_data).to be_a(DropboxApi::Metadata::File)
+      expect(file_data.name).to eq('new_file.txt')
+    end
+
     it 'uploads a file', :cassette => "chunked_uploader/success" do
       content = File.open(File.join(DropboxScaffoldBuilder.fixtures_path, "file.txt"))
 

--- a/spec/fixtures/vcr_cassettes/chunked_uploader/success_with_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/chunked_uploader/success_with_empty_string.yml
@@ -1,0 +1,112 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://content.dropboxapi.com/2/files/upload_session/start
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_AUTHORIZATION_BEARER
+      User-Agent:
+      - Faraday v0.12.2
+      Dropbox-Api-Arg:
+      - "{}"
+      Content-Type:
+      - application/octet-stream
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 13 Nov 2018 01:32:24 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      X-Server-Response-Time:
+      - '305'
+      X-Dropbox-Request-Id:
+      - 3d94c9b1a684dde29cc0ce93da303f85
+      X-Robots-Tag:
+      - noindex, nofollow, noimageindex
+    body:
+      encoding: ASCII-8BIT
+      string: '{"session_id": "AAAAAAAAAvUVNeWqT7Qydg"}'
+    http_version: 
+  recorded_at: Tue, 13 Nov 2018 01:32:24 GMT
+- request:
+    method: post
+    uri: https://content.dropboxapi.com/2/files/upload_session/finish
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_AUTHORIZATION_BEARER
+      User-Agent:
+      - Faraday v0.12.2
+      Dropbox-Api-Arg:
+      - '{"cursor":{"session_id":"AAAAAAAAAvUVNeWqT7Qydg","offset":0},"commit":{"path":"/dropbox_api_fixtures/chunked_uploader/new_file.txt"}}'
+      Content-Type:
+      - application/octet-stream
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 13 Nov 2018 01:32:25 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      X-Server-Response-Time:
+      - '531'
+      X-Dropbox-Request-Id:
+      - f98186e70c19724ad0da02b8b83c8d19
+      X-Robots-Tag:
+      - noindex, nofollow, noimageindex
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name": "new_file.txt", "path_lower": "/dropbox_api_fixtures/chunked_uploader/new_file.txt",
+        "path_display": "/dropbox_api_fixtures/chunked_uploader/new_file.txt", "id":
+        "id:px0KNy0NvQsAAAAAAAABHw", "client_modified": "2018-11-13T01:29:17Z", "server_modified":
+        "2018-11-13T01:29:17Z", "rev": "14ae517a440", "size": 0, "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}'
+    http_version: 
+  recorded_at: Tue, 13 Nov 2018 01:32:25 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
Hello.

I have found minor issue using chunked uploader.

# How to reproduce

```ruby
# reproduce_problem.rb

require 'dropbox_api'

client = DropboxApi::Client.new(token)
content = ""
client.upload_by_chunks('/test.txt', content, mode: :add, autorename: true)
```

```bash
[retro@retro  dropbox_api (master %=)]❤ ruby reproduce_problem.rb 
Traceback (most recent call last):
        4: from reproduce_problem.rb:7:in `<main>'
        3: from /home/retro/.gem/ruby/2.5.1/gems/dropbox_api-0.1.12/lib/dropbox_api/endpoints/virtual/upload_by_chunks.rb:44:in `upload_by_chunks'
        2: from /home/retro/.gem/ruby/2.5.1/gems/dropbox_api-0.1.12/lib/dropbox_api/chunked_uploader.rb:17:in `start'
        1: from /home/retro/.gem/ruby/2.5.1/gems/dropbox_api-0.1.12/lib/dropbox_api/client.rb:14:in `block in add_endpoint'
/home/retro/.gem/ruby/2.5.1/gems/dropbox_api-0.1.12/lib/dropbox_api/endpoints/files/upload_session_start.rb:34:in `block in <class:UploadSessionStart>': undefined method `bytesize' for nil:NilClass (NoMethodError)
```

# TL;DR; reason

```ruby
chunk_size = 4 * 1024 * 1024 # default value, anyway anything >= 1 will fail the same way
StringIO.new("").read(chunk_size).bytesize #=> NoMethodError (undefined method `bytesize' for nil:NilClass)
StringIO.new("test").read(chunk_size).bytesize #=> 4
```

Even first reading of IO can be the end (resulting into `nil`) which is not expected at https://github.com/Jesus/dropbox_api/blob/42b597f8995011afaf7b531c3e5bed82c29de77e/lib/dropbox_api/chunked_uploader.rb#L15.

# Detailed reason

1. empty string is casted to `StringIO` and passed to chunked uploader at https://github.com/Jesus/dropbox_api/blob/42b597f8995011afaf7b531c3e5bed82c29de77e/lib/dropbox_api/endpoints/virtual/upload_by_chunks.rb#L41-L44

2. chunk size is initialized to 4MB at https://github.com/Jesus/dropbox_api/blob/42b597f8995011afaf7b531c3e5bed82c29de77e/lib/dropbox_api/chunked_uploader.rb#L6

3. reading chunk from empty `StringIO` (resulting into `nil`) and passing it into `upload_session_start` happens at https://github.com/Jesus/dropbox_api/blob/42b597f8995011afaf7b531c3e5bed82c29de77e/lib/dropbox_api/chunked_uploader.rb#L15-L17

4. final `bytesize` call at `nil` is done at https://github.com/Jesus/dropbox_api/blob/42b597f8995011afaf7b531c3e5bed82c29de77e/lib/dropbox_api/endpoints/files/upload_session_start.rb#L34

# Summary

This is a naive fix, which passes an empty string when the chunk is empty.
As a result an empty file is created in the desired Dropbox account.

PS: With this patch `upload_by_chunks` and `upload` works the same way with empty content.