### PR TITLE
Update oauth2 dependency.

### DIFF
--- a/dropbox_api.gemspec
+++ b/dropbox_api.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"
 
-  spec.add_dependency "oauth2", ">= 1.1", "<= 1.4"
+  spec.add_dependency "oauth2", "~> 1.1"
   spec.add_dependency "faraday", ">= 0.8", "<= 0.15.2"
 end


### PR DESCRIPTION
oauth2 v1.4.0 restricts the faraday gem to versions < 0.13, which currently prevents me from updating other gems that require faraday = 0.13.

Would you consider opening up the oauth2 dependency to at least version 1.4.1?