### PR TITLE
make path data optional in file metadata

### DIFF
--- a/lib/dropbox_api/metadata/file.rb
+++ b/lib/dropbox_api/metadata/file.rb
@@ -21,8 +21,8 @@ module DropboxApi::Metadata
   # ```
   class File < Base
     field :name, String
-    field :path_lower, String
-    field :path_display, String
+    field :path_lower, String, :optional
+    field :path_display, String, :optional
     field :id, String
     field :client_modified, Time
     field :server_modified, Time

--- a/spec/metadata/file_spec.rb
+++ b/spec/metadata/file_spec.rb
@@ -146,4 +146,11 @@ context DropboxApi::Metadata::File do
 
     expect(file.to_hash).to eq(file_hash)
   end
+
+  it "works without path data" do
+    file_hash = build_file_hash.reject { |k, _| %w(path_display path_lower).include?(k) }
+    file = DropboxApi::Metadata::File.new(file_hash)
+    expect(file).to be_a(DropboxApi::Metadata::File)
+  end
+
 end


### PR DESCRIPTION
addresses #50 

happy to make any style changes, etc. 

reference: https://www.dropbox.com/developers/documentation/http/documentation#files-list_folder