### PR TITLE
Provide ability to access root (team) folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,24 @@ Check out the
 [method documentation](http://www.xuuso.com/dropbox_api/DropboxApi/Client.html#upload_by_chunks-instance_method)
 to find out all available options.
 
+### Accessing Team Folders
+
+In order to access your team scope you need to add the namespace_id to you request headers.
+This can be done using the middlewere layer as per the below:
+
+```ruby
+client = DropboxApi::Client.new("VofXAX8D...")
+#=> #<DropboxApi::Client ...>
+namespace_id = client.get_current_account.root_info.root_namespace_id
+client.middleware.prepend do |connection|
+  connection.headers['Dropbox-API-Path-Root'] = "{\".tag\": \"namespace_id\", \"namespace_id\": \"#{namespace_id}\"}"
+end
+
+client.list_folder('')
+#=> Now returns the team folders
+```
+
+
 ## Dependencies
 
 This gem depends on

--- a/lib/dropbox_api/metadata/basic_account.rb
+++ b/lib/dropbox_api/metadata/basic_account.rb
@@ -15,7 +15,12 @@ module DropboxApi::Metadata
   #   "disabled": false,
   #   "is_teammate": true,
   #   "profile_photo_url": "https://dl-web.dropbox.com/account_photo/get/dbid%3AAAH4f99T0taONIb-OurWxbNQ6ywGRopQngc?vers=1453416696524&size=128x128",
-  #   "team_member_id": "dbmid:AAHhy7WsR0x-u4ZCqiDl5Fz5zvuL3kmspwU"
+  #   "team_member_id": "dbmid:AAHhy7WsR0x-u4ZCqiDl5Fz5zvuL3kmspwU",
+  #   "root_info": {
+  #     root_namespace_id: 7,
+  #     home_namespace_id: 1,
+  #     home_path: "/Franz Ferdinand"
+  #   }
   # }
   # ```
   class BasicAccount < Base
@@ -27,5 +32,6 @@ module DropboxApi::Metadata
     field :is_teammate, :boolean, :optional
     field :profile_photo_url, String, :optional
     field :team_member_id, :boolean, :optional
+    field :root_info, DropboxApi::Metadata::RootInfo, :optional
   end
 end

--- a/lib/dropbox_api/metadata/root_info.rb
+++ b/lib/dropbox_api/metadata/root_info.rb
@@ -1,0 +1,16 @@
+module DropboxApi::Metadata
+  # Example of a serialized {BasicAccount} object:
+  #
+  # ```json
+  # {
+  #   root_namespace_id: 7,
+  #   home_namespace_id: 1,
+  #   home_path: "/Franz Ferdinand"
+  # }
+  # ```
+  class RootInfo < Base
+    field :root_namespace_id, String
+    field :home_namespace_id, String
+    field :home_path, String
+  end
+end


### PR DESCRIPTION
This requires access to `RootInfo` object in the `get_current_account` endpoint
with the results being used to set the root namespace on subsequent requests.

@Jesus Can you please reset the VCR cassettes so they get the `root_info` object, it should all
work as I have it working locally with monkey patching. :) 