### PR TITLE
Added the fix suggested by @kmuto

### DIFF
--- a/lib/dropbox_api/middleware/path_root.rb
+++ b/lib/dropbox_api/middleware/path_root.rb
@@ -20,7 +20,7 @@ module DropboxApi::MiddleWare
       JSON.dump(
         DropboxApi::Metadata::NamespaceId.new({
           'namespace_id' => namespace_id
-        })
+        }).to_hash
       )
     end
 


### PR DESCRIPTION
Works well for me too as suggested by @kmuto

```irb(main):001:0> dbx = DropboxApi::Client.new("..")
irb(main):002:0> dbx.get_current_account
=> #<DropboxApi::Metadata::BasicAccount:0x0000...  @account_id=.. .@root_info=#<DropboxApi::Metadata::TeamRootInfo:0x000...  @root_namespace_id="1234", @home_namespace_id="4321", @home_path="/Marcus Gustavsson">>
irb(main):003:0> dbx.namespace_id = dbx.get_current_account.root_info.root_names
pace_id
irb(main):004:0> dbx.list_folder ""
=> #<DropboxApi::Results::ListFolderResult:0x00...  @data={"entries"=>[{".tag"=>"folder", "name"=>"Marcus Gustavsson", ...```