### PR TITLE
Implements #81 Refresh tokens support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ You can obtain an authorization code with this library:
 
 ```ruby
 authenticator = DropboxApi::Authenticator.new(CLIENT_ID, CLIENT_SECRET)
-authenticator.authorize_url #=> "https://www.dropbox.com/..."
+authenticator.auth_code.authorize_url #=> "https://www.dropbox.com/..."
 
 # Now you need to open the authorization URL in your browser,
 # authorize the application and copy your code.
 
-auth_bearer = authenticator.get_token(CODE) #=> #<OAuth2::AccessToken ...>`
+auth_bearer = authenticator.auth_code.get_token(CODE) #=> #<OAuth2::AccessToken ...>`
 auth_bearer.token #=> "VofXAX8D..."
 # Keep this token, you'll need it to initialize a `DropboxApi::Client` object
 ```
@@ -130,7 +130,7 @@ In case of use of Authenticator approach, following change has to be applied:
 authenticator = DropboxApi::Authenticator.new(CLIENT_ID, CLIENT_SECRET)
 
 # Change 1: ask for offline token type:
-authenticator.authorize_url(token_access_type: 'offline') #=> "https://www.dropbox.com/..." 
+authenticator.auth_code.authorize_url(token_access_type: 'offline') #=> "https://www.dropbox.com/..." 
 
 # Now you need to open the authorization URL in your browser,
 # authorize the application and copy your code.
@@ -141,7 +141,7 @@ token = MyDropboxToken.from_code(authenticator, CODE)  #=> #<DropboxApi::Token .
 token.save! 
 ```
 
-#### Using token performin API calls
+#### Using token performing API calls
 
 ```ruby
 authenticator = DropboxApi::Authenticator.new(DROPBOX_APP_KEY, DROPBOX_APP_SECRET)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Furthermore overriding the class on your own and implement `save_token` method a
 class MyDropboxToken < DropboxApi::Token
   def save_token(token)
     # Implement your own store method, token is a `Hash` instance in here, easy to serialize:
-    puts 'Token to be saved somwhere in the database', token
+    puts 'Token to be saved somewhere in the database', token
   end
 end
 ```

--- a/lib/dropbox_api/authenticator.rb
+++ b/lib/dropbox_api/authenticator.rb
@@ -14,4 +14,43 @@ module DropboxApi
 
     def_delegators :@auth_code, :authorize_url, :get_token
   end
+
+
+  class Token
+    extend Forwardable
+    def_delegators :@token, :token, :refresh_token, :expired
+
+    def initialize(authenticator, token_hash = nil)
+      @authenticator = authenticator
+      load_token(token_hash) if token_hash
+    end
+    
+    def self.from_code(authenticator, code) 
+      self.new(authenticator, authenticator.get_token(code))
+    end
+    
+    def load_token(token_hash) 
+      if token_hash.is_a?(OAuth2::AccessToken)
+        @token = token_hash 
+      else
+        @token = OAuth2::AccessToken.from_hash(@authenticator, token_hash)
+      end
+    end
+    
+    def refresh_token()
+      @token = @token.refresh! 
+      save!
+    end
+    
+    def save_token(token_hash); end
+    
+    def save! 
+      save_token(@token.to_hash)
+    end
+
+    def short_lived_token()
+      refresh_token if @token.expired?
+      @token.token
+    end
+  end
 end

--- a/lib/dropbox_api/authenticator.rb
+++ b/lib/dropbox_api/authenticator.rb
@@ -3,18 +3,13 @@ require 'oauth2'
 
 module DropboxApi
   class Authenticator < OAuth2::Client
-    extend Forwardable
-
     def initialize(client_id, client_secret)
-      @auth_code = OAuth2::Client.new(client_id, client_secret, {
+      super(client_id, client_secret, {
         authorize_url: 'https://www.dropbox.com/oauth2/authorize',
         token_url: 'https://api.dropboxapi.com/oauth2/token'
-      }).auth_code
+      })
     end
-
-    def_delegators :@auth_code, :authorize_url, :get_token
   end
-
 
   class Token
     extend Forwardable
@@ -26,7 +21,7 @@ module DropboxApi
     end
     
     def self.from_code(authenticator, code) 
-      self.new(authenticator, authenticator.get_token(code))
+      self.new(authenticator, authenticator.auth_code.get_token(code))
     end
     
     def load_token(token_hash) 

--- a/lib/dropbox_api/connection_builder.rb
+++ b/lib/dropbox_api/connection_builder.rb
@@ -12,8 +12,7 @@ module DropboxApi
     def build(url)
       Faraday.new(url) do |connection|
         middleware.apply(connection) do
-          connection.authorization :Bearer, @oauth_bearer
-
+          connection.authorization :Bearer, @oauth_bearer.is_a?(DropboxApi::Token) ? @oauth_bearer.short_lived_token : @oauth_bearer
           yield connection
         end
       end


### PR DESCRIPTION
This change implements use of dynamic tokens, that refresh automatically after they expire with the simplified procedure (without user interaction needed).
The details how to do that are described in dedicated section of README.md. 