### PR TITLE
Add refresh tokens support (based on PR#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ DropboxApi::Client.new
 Note that setting an ENV variable is only a feasible choice if you're only
 using one account.
 
+
 #### Option A: Get your access token from the website
 
 The easiest way to obtain an access token is to get it from the Dropbox website.
@@ -75,12 +76,12 @@ You can obtain an authorization code with this library:
 
 ```ruby
 authenticator = DropboxApi::Authenticator.new(CLIENT_ID, CLIENT_SECRET)
-authenticator.authorize_url #=> "https://www.dropbox.com/..."
+authenticator.auth_code.authorize_url #=> "https://www.dropbox.com/..."
 
 # Now you need to open the authorization URL in your browser,
 # authorize the application and copy your code.
 
-auth_bearer = authenticator.get_token(CODE) #=> #<OAuth2::AccessToken ...>`
+auth_bearer = authenticator.auth_code.get_token(CODE) #=> #<OAuth2::AccessToken ...>`
 auth_bearer.token #=> "VofXAX8D..."
 # Keep this token, you'll need it to initialize a `DropboxApi::Client` object
 ```
@@ -88,11 +89,77 @@ auth_bearer.token #=> "VofXAX8D..."
 #### Standard OAuth 2 flow
 
 This is what many web applications will use. The process is described in
-Dropbox's [OAuth guide]
-(https://www.dropbox.com/developers/reference/oauth-guide#oauth-2-on-the-web).
+Dropbox's [OAuth guide](https://www.dropbox.com/developers/reference/oauth-guide#oauth-2-on-the-web).
 
-If you have a Rails application, you might be interested in this [setup
-guide](http://jesus.github.io/dropbox_api/file.rails_setup.html).
+If you have a Rails application, you might be interested in this [setup guide](http://jesus.github.io/dropbox_api/file.rails_setup.html).
+
+
+### Authorize with short lived token
+
+Dropbox introduces, effective on September, 30 2021, a new policy for OAuth2 token based authentication. It impacts all new applications as well as being suggested for existing apps. You can [read more about the change applied and how it impacts the authentication proces](https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens#updating-access-token-type)
+
+In short, the persistent, long lived tokens are being replaced with short lived tokens, which are valid for up to a few hours. With the current approach the application has to revalidate permission by executing a full handshake involving an interactive user to make a new token, which will expire.
+
+Apps that require background ('offline') access but have not yet implemented refresh tokens will be impacted.
+
+To keep “offline” access in the background the application must change authentication strategy and obtain a new token every time the old one expires with a simplified `refresh` procedure. The app performing a full token generation (the first step) must ask for special “offline” mode which will generate, except regular authentication, an additional refresh token that can be reused for future quick re-refresh procedures. Thus the refresh token is important and has to be securely stored with the application, as it will be required every time the short term token expires.
+
+To prevent the app to lose connectivity and access to Dropbox resources using the library following changes has to be applied:
+
+#### Implement own `DropboxApi::Token`
+
+Application must replace current fixed token if it has used one with a dynamic, secure store that updates every time a token expires. For that purpose a new class `DropboxApi::Token` has been introduced, which implements short lived tokens, and replaces current fixed string approach.
+
+Furthermore overriding the class on your own and implement `save_token` method allows to keep tokens within your application secure store or session data, every time needed.
+
+```ruby
+class MyDropboxToken < DropboxApi::Token
+  def save_token(token)
+    # Implement your own store method, token is a `Hash` instance in here, easy to serialize:
+    puts 'Token to be saved somewhere in the database', token
+  end
+end
+```
+
+#### Obtaining the offline token
+
+The application must obtain a new token for “offline use”.
+In case of use of Authenticator approach, following change has to be applied:
+
+```ruby
+authenticator = DropboxApi::Authenticator.new(CLIENT_ID, CLIENT_SECRET)
+
+# Change 1: ask for offline token type:
+authenticator.auth_code.authorize_url(token_access_type: 'offline') #=> "https://www.dropbox.com/..."
+
+# Now you need to open the authorization URL in your browser,
+# authorize the application and copy your code.
+
+# Change 2: Use own token to save it
+token = MyDropboxToken.get_token(authenticator, CODE)  #=> #<DropboxApi::Token ...>`
+# First save your data using overridden token implementation:
+token.save!
+```
+
+#### Using A Token To Perform API Calls
+
+```ruby
+authenticator = DropboxApi::Authenticator.new(DROPBOX_APP_KEY, DROPBOX_APP_SECRET)
+
+# Change 3: Use own class and the deserialized token to initialize the Client:
+
+token_hash = DESERIALIZED_TOKEN_HASH # Implement your own method to load the hash from secure store
+token = MyDropboxToken.new(authenticator, token_hash)
+
+# Initialize API with a dynamic Token:
+dropbox = DropboxApi::Client.new(token)
+
+# Enjoy the API:
+puts dropbox.get_metadata('/Temp/duck.jpg').to_hash
+```
+
+NOTE: When token expires it will automatically call refresh procedure in the background and invoke `save_token`
+method from overridden class, to keep new token secure for the future use.
 
 ### Performing API calls
 

--- a/lib/dropbox_api.rb
+++ b/lib/dropbox_api.rb
@@ -6,6 +6,7 @@ require 'json'
 require 'faraday'
 
 require 'dropbox_api/authenticator'
+require 'dropbox_api/oauth_token'
 
 require 'dropbox_api/metadata/base'
 require 'dropbox_api/metadata/field'

--- a/lib/dropbox_api/authenticator.rb
+++ b/lib/dropbox_api/authenticator.rb
@@ -3,15 +3,11 @@ require 'oauth2'
 
 module DropboxApi
   class Authenticator < OAuth2::Client
-    extend Forwardable
-
     def initialize(client_id, client_secret)
-      @auth_code = OAuth2::Client.new(client_id, client_secret, {
+      super(client_id, client_secret, {
         authorize_url: 'https://www.dropbox.com/oauth2/authorize',
         token_url: 'https://api.dropboxapi.com/oauth2/token'
-      }).auth_code
+      })
     end
-
-    def_delegators :@auth_code, :authorize_url, :get_token
   end
 end

--- a/lib/dropbox_api/connection_builder.rb
+++ b/lib/dropbox_api/connection_builder.rb
@@ -17,8 +17,7 @@ module DropboxApi
           namespace_id: self.namespace_id
         }
         middleware.apply(connection) do
-          connection.authorization :Bearer, @oauth_bearer
-
+          connection.authorization :Bearer, @oauth_bearer.is_a?(DropboxApi::Token) ? @oauth_bearer.short_lived_token : @oauth_bearer
           yield connection
         end
       end

--- a/lib/dropbox_api/oauth_token.rb
+++ b/lib/dropbox_api/oauth_token.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'oauth2'
+
+module DropboxApi
+  class Token
+    extend Forwardable
+    def_delegators :@token, :token, :refresh_token, :expired
+
+    def initialize(authenticator, token_hash = nil)
+      @authenticator = authenticator
+      load_token(token_hash) if token_hash
+    end
+
+    def self.get_token(authenticator, code, params = {})
+      self.new(authenticator, authenticator.auth_code.get_token(code, params))
+    end
+
+    def load_token(token_hash)
+      if token_hash.is_a?(OAuth2::AccessToken)
+        @token = token_hash
+      else
+        @token = OAuth2::AccessToken.from_hash(@authenticator, token_hash)
+      end
+    end
+
+    def refresh_token()
+      @token = @token.refresh!
+      save!
+    end
+
+    def save_token(token_hash); end
+
+    def save!
+      save_token(@token.to_hash)
+    end
+
+    def short_lived_token()
+      refresh_token if @token.expired?
+      @token.token
+    end
+  end
+end


### PR DESCRIPTION
This PR is based on https://github.com/Jesus/dropbox_api/pull/83.

I fixed all comments from it.

@Jesus let's try to merge this ASAP. Because starting September 30th, 2021, the Dropbox OAuth flow will no longer return long-lived access tokens. It will instead return short-lived access tokens, and optionally return refresh tokens. 