### PR TITLE
Fix Faraday Deprication Notice

### DIFF
--- a/lib/dropbox_api/connection_builder.rb
+++ b/lib/dropbox_api/connection_builder.rb
@@ -47,7 +47,7 @@ module DropboxApi
           namespace_id: self.namespace_id
         }
         middleware.apply(connection) do
-          connection.authorization :Bearer, bearer
+          connection.request :authorization, 'Bearer', bearer
           yield connection
         end
       end


### PR DESCRIPTION
This resolves #89 , getting rid of the Faraday deprivation notice on each request.

See: https://lostisland.github.io/faraday/middleware/authentication