### PR TITLE
Address `Faraday::Connection#authorization` deprecation warning

### DIFF
--- a/lib/dropbox_api/connection_builder.rb
+++ b/lib/dropbox_api/connection_builder.rb
@@ -47,7 +47,7 @@ module DropboxApi
           namespace_id: self.namespace_id
         }
         middleware.apply(connection) do
-          connection.authorization :Bearer, bearer
+          connection.request :authorization, :Bearer, bearer
           yield connection
         end
       end

--- a/lib/dropbox_api/endpoints/rpc_notify.rb
+++ b/lib/dropbox_api/endpoints/rpc_notify.rb
@@ -3,7 +3,7 @@ module DropboxApi::Endpoints
   class RpcNotify < DropboxApi::Endpoints::Rpc
     def build_connection
       @connection = @builder.build('https://notify.dropboxapi.com') do |c|
-        c.headers.delete 'Authorization'
+        c.builder.handlers.delete(Faraday::Request::Authorization)
 
         c.response :decode_result
       end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -27,6 +27,7 @@ module DropboxApi
         [
           DropboxApi::MiddleWare::PathRoot,
           MiddlewareStart,
+          Faraday::Request::Authorization,
           MiddlewareMiddle,
           MiddlewareEnd
         ],


### PR DESCRIPTION
Fixes #89:
```
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```

The tests pass, but I've never touched Faraday or VCR before, so I'm sure a sanity check is in order.

It may be worth noting that when I remove the `list_folder_longpoll` VCR fixtures and re-run the tests, I do get this one failure:

```
Failures:

  1) DropboxApi::Client#list_folder_longpoll indicates if there're changes
     Failure/Error: expect(result.changes).to be_truthy

       expected: truthy value
            got: false
     # ./spec/endpoints/files/list_folder_longpoll_spec.rb:22:in `block (2 levels) in <top (required)>'
     # ./spec/support/vcr.rb:36:in `block (3 levels) in <top (required)>'
     # ./spec/support/vcr.rb:36:in `block (2 levels) in <top (required)>'

Finished in 54.28 seconds (files took 0.93252 seconds to load)
210 examples, 1 failure

Failed examples:

rspec ./spec/endpoints/files/list_folder_longpoll_spec.rb:19 # DropboxApi::Client#list_folder_longpoll indicates if there're changes
```