### PR TITLE
allow version 2.x of oauth dependency

### DIFF
--- a/dropbox_api.gemspec
+++ b/dropbox_api.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'faraday', '< 3.0'
-  spec.add_dependency 'oauth2', '~> 1.1'
+  spec.add_dependency 'oauth2', '>= 1.1', "< 3"
 end


### PR DESCRIPTION
Closes #96

Note oauth 1.x is still allowed by gemspec, just expanded to allow 2.x too.  OAuth release notes expect no problems from 2.x for most uses. 

```
You have installed oauth2 version 1.4.11, which is EOL.
No further support is anticipated for the 1.4.x series.

OAuth2 version 2 is released.
There are BREAKING changes, but most will not encounter them, and upgrading should be easy!

We have made two other major migrations:
1. master branch renamed to main
2. Github has been replaced with Gitlab

Please see:
• https://gitlab.com/oauth-xx/oauth2#what-is-new-for-v20
• https://gitlab.com/oauth-xx/oauth2/-/blob/main/CHANGELOG.md
• https://groups.google.com/g/oauth-ruby/c/QA_dtrXWXaE

Please upgrade, report issues, and support the project! Thanks, |7eter l-|. l3oling
```
