### PR TITLE
Add undocumented match type returned by API

### DIFF
--- a/lib/dropbox_api/metadata/search_match_type_v2.rb
+++ b/lib/dropbox_api/metadata/search_match_type_v2.rb
@@ -2,10 +2,12 @@
 
 module DropboxApi::Metadata
   class SearchMatchTypeV2 < DropboxApi::Metadata::Tag
+    # both_filename_and_content is undocumented, but it's returned by the API.
     VALID_VALUES = %i[
       filename
       file_content
       filename_and_content
+      both_filename_and_content
       image_content
     ].freeze
 


### PR DESCRIPTION
API can return `both_filename_and_content` as a value for MatchType. It's undocumented but I found it in the wild.