### PR TITLE
allow version 2.x of oauth dependency

### DIFF
--- a/dropbox_api.gemspec
+++ b/dropbox_api.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'faraday', '< 3.0'
-  spec.add_dependency 'oauth2', '~> 1.1'
+  spec.add_dependency 'oauth2', '>= 1.1', '< 3'
 end


### PR DESCRIPTION
Fixes https://github.com/Flightlogger/flightlogger/issues/19443